### PR TITLE
Removed dead code causing compilation errors on Ubuntu 16.10

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -256,20 +256,6 @@ double amax(double* x, long n){
     return th;
 }
 
-long lomax(long* x, long n){
-    long i;
-    //long im=-1;
-    long th = -1;
-    for(i=0; i<n; i++){
-        if(x[i]>th && isnan(x[i])==0 && isinf(x[i])==0){
-            //im = i;
-            th = x[i];
-        }
-    }
-    return th;
-}
-
-
 double doub(double x){
     return x*x;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -51,7 +51,6 @@ long Fread(double* x, long sizeOf, long N, gzFile f);
 
 long imax(double* x, long n);
 //double max(double* x, long n);
-long lomax(long* x, long n);
 double doub(double x);
 
 double esum(double *x, long n, double y);


### PR DESCRIPTION
The function lomax calls isnan with a long.
This causes the compilation to fail on ubuntu 16.10 with
gcc version 6.2.0-5ubuntu12 and glibc version 2.24-3ubuntu1.
The function is never called, so I simply removed it.

Error message:
util.c: In function ‘lomax’:
util.c:264:9: error: non-floating-point argument in call to function ‘__builtin_isnan’
         if(x[i]>th && isnan(x[i])==0 && isinf(x[i])==0){
         ^~
util.c:264:9: error: non-floating-point argument in call to function ‘__builtin_isinf_sign’
Makefile:23: recipe for target 'util.o' failed
make: *** [util.o] Error 1