### PR TITLE
Fixed order of linked libraries, which matters for static builds.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ INTELLIB=/software/intel-tools-2015/lib/intel64
 
 CC=gcc
 CFLAGS := $(CFLAGS) -std=gnu99 -I/usr/include -I/usr/include/gsl -fpic -g -O2
-LDFLAGS := $(LDFLAGS) -lf2c -lblas -lgslcblas -llapack -lgsl -lm -lz -lpthread
+LDFLAGS := $(LDFLAGS) -lgslcblas -lgsl -llapack -lblas  -lm -lz -lpthread -lf2c
 
 PROGRAM = rasqual
 OBJS = usage.o parseVCF.o sort.o nbglm.o nbem.o util.o


### PR DESCRIPTION
This probably does not affect many people, but I need to compile with static clapack libraries for my HPC environment. The order libraries are listed in matters for static libraries, and this commit fixes that.
I also created a [Dockerfile](https://github.com/eivindgl/rasqual-docker/blob/static_clapack/Dockerfile) for a proof of concept build environment.